### PR TITLE
bump upload-pages-artifact version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - run: npm install --locked
       - run: npx parcel build --public-url .
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist
   deploy:


### PR DESCRIPTION
`actions/upload-pages-artifact@v1` is deprecated, we need to bump it to allow deploying new changes